### PR TITLE
Fix UI getting cut off when Global Font Scale is set to > 12.0pt

### DIFF
--- a/CrossUp.cs
+++ b/CrossUp.cs
@@ -104,6 +104,18 @@ namespace CrossUp
                 TweenAllButtons();
             }
 
+            if (Status.initialized && Service.ClientState.IsLoggedIn && Ref.UnitBases.Cross != null)
+            {
+                try
+                {
+                    UpdateBarState();
+                }
+                catch (Exception ex)
+                {
+                    PluginLog.Log(ex + "");
+                }
+            }
+
             return;
         }
         private void Initialize()

--- a/CrossUp.cs
+++ b/CrossUp.cs
@@ -7,7 +7,6 @@ using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using System;
 using System.Threading.Tasks;
-using XivCommon;
 using ClientStructsFramework = FFXIVClientStructs.FFXIV.Client.System.Framework.Framework;
 using DalamudFramework = Dalamud.Game.Framework;
 
@@ -18,7 +17,6 @@ namespace CrossUp
         public string Name => "CrossUp";
         private const string mainCommand = "/pcrossup";
         private readonly ActionManager* actionManager;
-        public XivCommonBase XivCommon { get; private set; }
         private DalamudPluginInterface PluginInterface { get; init; }
         private CommandManager CommandManager { get; init; }
         private Configuration Configuration { get; init; }
@@ -48,7 +46,6 @@ namespace CrossUp
             pluginInterface.Create<Service>();
 
             this.CrossUpUI = new CrossUpUI(this.Configuration, this);
-            this.XivCommon = new XivCommonBase();
 
             actionBarBaseUpdateHook ??= Common.Hook<ActionBarBaseUpdate>("E8 ?? ?? ?? ?? 83 BB ?? ?? ?? ?? ?? 75 09", ActionBarBaseUpdateDetour);
             actionBarBaseUpdateHook?.Enable();
@@ -71,19 +68,6 @@ namespace CrossUp
         {
             this.CrossUpUI.SettingsVisible = true;
         }
-
-        // Separate EXHB feature toggled on or off
-        public void EnableEx()
-        {
-            UpdateBarState(true, false);
-            return;
-        }
-        public void DisableEx()
-        {
-            ArrangeAndFill(0, 0, true, false);
-            ResetHud();
-            return;
-        }
         public void Dispose()   // put all the bars back in their normal places and take out our hooks
         {
             actionBarBaseUpdateHook?.Disable();
@@ -91,12 +75,10 @@ namespace CrossUp
             CommandManager.RemoveHandler(mainCommand);
             this.Configuration.Split = 0;
             this.Configuration.SepExBar = false;
-            ArrangeAndFill(0, 0, true, false);
-            ResetHud();
+            DisableEx();
             SetSelectColor(true);
             Status.initialized = false;
             CrossUpUI.Dispose();
-            XivCommon.Dispose();
         }
 
         // HOOKS AND EVENTS
@@ -184,31 +166,48 @@ namespace CrossUp
             xBar->ExpandedHoldControlsLTRT > 0 ? 3 : // L->R EX BAR
             xBar->ExpandedHoldControlsRTLT > 0 ? 4 : // R->L EX BAR
 
-            // there's probably a better way to find these two, watching the UI node means we'll always be one frame late
+            // need a better way to find these two, watching the UI node means we'll always be one frame late
             baseLL->UldManager.NodeList[3]->IsVisible ? 5 : // WXHB L
             baseRR->UldManager.NodeList[3]->IsVisible ? 6 : // WXHB R
                                                         0;
             return newCrossBarState;
         }
 
-        public void ExBarActivate(int barID)    // runs when a bar is selected to be one of the borrowed bars in CrossUp configs
+        public void EnableEx()
         {
-            var baseEx = Ref.UnitBases.ActionBar[barID];
-            if (baseEx == null)
-            {
-                return;
-            }
+            var lID = this.Configuration.borrowBarL;
+            var rID = this.Configuration.borrowBarR;
 
-            XivCommon.Functions.Chat.SendMessage($"/hotbar display " + (barID + 1) + " on");
+            if (lID < 0 || rID < 0) { return; }
 
-            for (var i = 9; i <= 20; i++)
-            {
-                baseEx->UldManager.NodeList[i]->Flags_2 |= 0xD;
-            }
+            EnableBorrowedBar(lID);
+            EnableBorrowedBar(rID);
 
             UpdateBarState(true, false);
             Task.Delay(20).ContinueWith(antecedent => { UpdateBarState(true, false); });
 
+            return;
+        }
+
+        public static bool[] wasHidden = { false, false, false, false, false, false, false, false, false, false };
+        public void EnableBorrowedBar(int id)
+        {
+            var unitBase = Ref.UnitBases.ActionBar[id];
+            if (unitBase == null) { return; }
+
+            var visID = (uint)(id + 485);
+            if (charConfigs->GetIntValue(visID) == 0)
+            {
+                wasHidden[id] = true;
+                charConfigs->SetOption(visID, 1);
+            }
+
+            for (var i = 9; i <= 20; i++) unitBase->UldManager.NodeList[i]->Flags_2 |= 0xD;
+        }
+        public void DisableEx()
+        {
+            ArrangeAndFill(0, 0, true, false);
+            ResetHud();
             return;
         }
 
@@ -221,21 +220,22 @@ namespace CrossUp
             public float ToScale { get; set; }
         }
 
-        public class Position
+        public class MetaSlot
         {
-            public float Scale { get; set; }
+            public bool Visible { get; set; }
             public int X { get; set; }
             public int Y { get; set; }
-            public int OrigX { get; set; }
-            public int OrigY { get; set; }
-            public bool Visible { get; set; }
+            public float Scale { get; set; }
             public ushort Width { get; set; }
             public ushort Height { get; set; }
+            public int OrigX { get; set; }
+            public int OrigY { get; set; }
             public ScaleTween? Tween { get; set; }
             public int ScaleIndex { get; set; }
             public AtkResNode* Node { get; set; }
             public float xMod { get; set; }
             public float yMod { get; set; }
+            public static implicit operator NodeEdit.PropertySet(MetaSlot p) => new() {X=p.X+p.xMod,Y=p.Y+p.yMod,Scale=p.Scale,Width=p.Width,Height=p.Height,Visible=p.Visible,OrigX=p.OrigX,OrigY=p.OrigY};
         }
 
         private void ArrangeAndFill(int select, int prevSelect = 0, bool forceArrange = false, bool HUDfixCheck = true) // the centrepiece of it all
@@ -258,13 +258,14 @@ namespace CrossUp
             // fix for misalignment after entering HUD Layout interface (unsure if this is sufficient)
             if (HUDfixCheck && baseXHB->X - rootNode->X - Math.Round(cfg.Split * scale) < 0) { baseXHB->X += (short)(cfg.Split * scale); }
 
-            NodeEdit.SetVarious(rootNode, new NodeEdit.NodeProps
+            NodeEdit.SetVarious(rootNode, new NodeEdit.PropertySet
             {
                 X = baseXHB->X - cfg.Split * scale,
                 Y = baseXHB->Y,
                 Width = (ushort)(588 + cfg.Split * 2),
                 Height = 210
             });
+
 
             int anchorX = (int)(rootNode->X + (146 * scale));
             int anchorY = (int)(rootNode->Y + (70 * scale));
@@ -368,7 +369,6 @@ namespace CrossUp
             int lId = this.Configuration.borrowBarL;
             int rId = this.Configuration.borrowBarR;
 
-
             var baseExL = Ref.UnitBases.ActionBar[lId];
             var baseExR = Ref.UnitBases.ActionBar[rId];
             if (baseExL == null || baseExR == null) { return; }
@@ -389,25 +389,21 @@ namespace CrossUp
             int rX = cfg.rX;
             int rY = cfg.rY;
 
-            NodeEdit.SetVarious(nodesExL[0], new NodeEdit.NodeProps
+            NodeEdit.SetVarious(nodesExL[0], new NodeEdit.PropertySet
             {
                 Scale = scale,
                 X = (float)(anchorX + lX * scale + cfg.Split),
                 Y = (float)(anchorY + lY * scale),
-                OriginX = 0,
-                OriginY = 0,
                 Visible = true,
                 Width = 295,
                 Height = 120
             });
 
-            NodeEdit.SetVarious(nodesExR[0], new NodeEdit.NodeProps
+            NodeEdit.SetVarious(nodesExR[0], new NodeEdit.PropertySet
             {
                 Scale = scale,
                 X = (float)(anchorX + rX * scale + cfg.Split),
                 Y = (float)(anchorY + rY * scale),
-                OriginX = 0,
-                OriginY = 0,
                 Visible = true,
                 Width = 295,
                 Height = 120
@@ -629,10 +625,10 @@ namespace CrossUp
                     break;
             }
         }
-        private void PlaceExButton(AtkResNode* node, int posID, float xMod = 0, float yMod = 0, int select = 0, bool Tween = false) //move a borrowed button into position and set its scale to animate if needed
+        private void PlaceExButton(AtkResNode* node, int msID, float xMod = 0, float yMod = 0, int select = 0, bool Tween = false) //move a borrowed button into position and set its scale to animate if needed
         {
-            var to = Ref.scaleMap[select, Ref.slotPositions[posID].ScaleIndex];
-            var pos = Ref.slotPositions[posID];
+            var to = Ref.scaleMap[select, Ref.metaSlots[msID].ScaleIndex];
+            var pos = Ref.metaSlots[msID];
             pos.xMod = xMod;
             pos.yMod = yMod;
             pos.Node = node;
@@ -660,15 +656,7 @@ namespace CrossUp
                 pos.Scale = to;
             }
 
-            NodeEdit.SetVarious(node, new NodeEdit.NodeProps
-            {
-                Scale = pos.Scale,
-                OriginX = pos.OrigX,
-                OriginY = pos.OrigY,
-                X = pos.X + xMod,
-                Y = pos.Y + yMod,
-                Visible = pos.Visible
-            });
+            NodeEdit.SetVarious(node,pos);
 
             return;
         }
@@ -684,14 +672,14 @@ namespace CrossUp
         {
             for (var i = start; i <= end; i++)
             {
-                Ref.slotPositions[i].Visible = show;
+                Ref.metaSlots[i].Visible = show;
             }
         }//set visibility for a range of slots at once
         private void SlotRangeScale(int start, int end, float scale)
         {
             for (var i = start; i <= end; i++)
             {
-                Ref.slotPositions[i].Scale = scale;
+                Ref.metaSlots[i].Scale = scale;
             }
         }//set scale for a range of slots at once
         private void SetExAlpha(AtkResNode** nodesL, AtkResNode** nodesR, byte alpha)
@@ -794,7 +782,7 @@ namespace CrossUp
 
             var gridType = GetCharConfig((uint)(barID + 501));
 
-            NodeEdit.SetVarious(nodes[0], new NodeEdit.NodeProps
+            NodeEdit.SetVarious(nodes[0], new NodeEdit.PropertySet
             {
                 Width = (ushort)Ref.barSizes[gridType].X,
                 Height = (ushort)Ref.barSizes[gridType].Y,
@@ -807,13 +795,18 @@ namespace CrossUp
 
             for (var i = 0; i < 12; i++)
             {
-                NodeEdit.SetVarious(nodes[20 - i], new NodeEdit.NodeProps
+                NodeEdit.SetVarious(nodes[20 - i], new NodeEdit.PropertySet
                 {
                     X = Ref.barGrids[gridType, i].X,
                     Y = Ref.barGrids[gridType, i].Y,
                     Visible = true,
                     Scale = 1F
                 });
+            }
+
+            if (wasHidden[barID] && (this.Configuration.borrowBarL < 1 || this.Configuration.borrowBarR < 1 || (barID != this.Configuration.borrowBarL && barID != this.Configuration.borrowBarR)) && charConfigs->GetIntValue((uint)(barID + 485)) == 1)
+            {
+                charConfigs->SetOption((uint)(barID + 485), 0);
             }
 
             SetKeybindVis(baseHotbar, true);
@@ -823,11 +816,11 @@ namespace CrossUp
         private void TweenAllButtons()  //run any extant tweens to animate button scale
         {
             Status.tweensExist = false;
-            for (var i = 0; i < Ref.slotPositions.Length; i++)
+            for (var i = 0; i < Ref.metaSlots.Length; i++)
             {
-                var pos = Ref.slotPositions[i];
-                var tween = pos.Tween;
-                var node = pos.Node;
+                var metaSlot = Ref.metaSlots[i];
+                var tween = metaSlot.Tween;
+                var node = metaSlot.Node;
                 if (tween != null && node != null)
                 {
                     Status.tweensExist = true;
@@ -836,20 +829,15 @@ namespace CrossUp
 
                     if (progress >= 1)
                     {
-                        pos.Tween = null;
-                        pos.Scale = tween.ToScale;
+                        metaSlot.Tween = null;
+                        metaSlot.Scale = tween.ToScale;
                     }
                     else
                     {
-                        pos.Scale = ((tween.ToScale - tween.FromScale) * (float)progress) + tween.FromScale;
+                        metaSlot.Scale = ((tween.ToScale - tween.FromScale) * (float)progress) + tween.FromScale;
                     }
 
-                    NodeEdit.SetVarious(node, new NodeEdit.NodeProps
-                    {
-                        X = pos.X + pos.xMod,
-                        Y = pos.Y + pos.yMod,
-                        Scale = pos.Scale
-                    });
+                    NodeEdit.SetVarious(node, metaSlot);
                 }
             }
             return;
@@ -890,10 +878,6 @@ namespace CrossUp
             }
 
             return contents;
-        }
-        private ButtonAction[] GetHotbarContents(int barID) //get a standard hotbar
-        {
-            return GetBarContentsByID(barID, 12);
         }
         private ButtonAction[] GetCrossbarContents()    //get whatever's on the cross hotbar
         {
@@ -948,8 +932,9 @@ namespace CrossUp
         }
         private int GetCharConfig(uint configID)    //get a char Config setting
         {
-            //  501-508: int from 0-5, represents selected grid layout for hotbars 1-8
-            //  515 - 523: toggle, share setting for hotbars 1 - 8
+            //  485-494: toggle, hotbar 1-10 (0-9 internally) visible or not
+            //  501-510: int from 0-5, represents selected grid layout for hotbars 1-10 (0-9 internally)
+            //  515-523: toggle, share setting for cross hotbars 1 - 8
             //  535: main cross hotbar layout   0 = dpad / button / dpad / button
             //                                  1 = dpad / dpad / button / button
             //  560: mapping for RL expanded cross hotbar

--- a/CrossUp.cs
+++ b/CrossUp.cs
@@ -53,7 +53,7 @@ namespace CrossUp
             Service.Framework.Update += FrameworkUpdate;
             Status.initialized = false;
         }
-        public static class Status
+        private static class Status
         {
             public static bool tweensExist = false;
             public static bool initialized = false;
@@ -189,7 +189,7 @@ namespace CrossUp
             return;
         }
 
-        public static bool[] wasHidden = { false, false, false, false, false, false, false, false, false, false };
+        private static bool[] wasHidden = { false, false, false, false, false, false, false, false, false, false };
         public void EnableBorrowedBar(int id)
         {
             var unitBase = Ref.UnitBases.ActionBar[id];
@@ -233,9 +233,9 @@ namespace CrossUp
             public ScaleTween? Tween { get; set; }
             public int ScaleIndex { get; set; }
             public AtkResNode* Node { get; set; }
-            public float xMod { get; set; }
-            public float yMod { get; set; }
-            public static implicit operator NodeEdit.PropertySet(MetaSlot p) => new() {X=p.X+p.xMod,Y=p.Y+p.yMod,Scale=p.Scale,Width=p.Width,Height=p.Height,Visible=p.Visible,OrigX=p.OrigX,OrigY=p.OrigY};
+            public float Xmod { get; set; }
+            public float Ymod { get; set; }
+            public static implicit operator NodeEdit.PropertySet(MetaSlot p) => new() {X=p.X+p.Xmod,Y=p.Y+p.Ymod,Scale=p.Scale,Width=p.Width,Height=p.Height,Visible=p.Visible,OrigX=p.OrigX,OrigY=p.OrigY};
         }
 
         private void ArrangeAndFill(int select, int prevSelect = 0, bool forceArrange = false, bool HUDfixCheck = true) // the centrepiece of it all
@@ -625,15 +625,13 @@ namespace CrossUp
                     break;
             }
         }
-        private void PlaceExButton(AtkResNode* node, int msID, float xMod = 0, float yMod = 0, int select = 0, bool Tween = false) //move a borrowed button into position and set its scale to animate if needed
+        private static void PlaceExButton(AtkResNode* node, int msID, float xMod = 0, float yMod = 0, int select = 0, bool Tween = false) //move a borrowed button into position and set its scale to animate if needed
         {
             var to = Ref.scaleMap[select, Ref.metaSlots[msID].ScaleIndex];
             var pos = Ref.metaSlots[msID];
-            pos.xMod = xMod;
-            pos.yMod = yMod;
+            pos.Xmod = xMod;
+            pos.Ymod = yMod;
             pos.Node = node;
-
-            var blah = (ActionBarSlotAction*)node;
 
             if (Tween && to != pos.Scale) //only make a new tween if the button isn't already at the target scale, otherwise just set
             {
@@ -668,14 +666,14 @@ namespace CrossUp
                 NodeEdit.SetVis(nodesR[i], show);
             }
         }
-        private void SlotRangeVis(int start, int end, bool show)
+        private static void SlotRangeVis(int start, int end, bool show)
         {
             for (var i = start; i <= end; i++)
             {
                 Ref.metaSlots[i].Visible = show;
             }
         }//set visibility for a range of slots at once
-        private void SlotRangeScale(int start, int end, float scale)
+        private static void SlotRangeScale(int start, int end, float scale)
         {
             for (var i = start; i <= end; i++)
             {
@@ -813,7 +811,7 @@ namespace CrossUp
             return;
         }
 
-        private void TweenAllButtons()  //run any extant tweens to animate button scale
+        private static void TweenAllButtons()  //run any extant tweens to animate button scale
         {
             Status.tweensExist = false;
             for (var i = 0; i < Ref.metaSlots.Length; i++)

--- a/CrossUp.cs
+++ b/CrossUp.cs
@@ -88,7 +88,10 @@ namespace CrossUp
         }
         private void FrameworkUpdate(DalamudFramework framework)
         {
-            if (!Status.initialized && Service.ClientState.IsLoggedIn && Ref.UnitBases.Cross != null)
+            if (!Service.ClientState.IsLoggedIn && Ref.UnitBases.Cross == null)
+                return;
+
+            if (!Status.initialized)
             {
                 try
                 {
@@ -103,17 +106,9 @@ namespace CrossUp
             {
                 TweenAllButtons();
             }
-
-            if (Status.initialized && Service.ClientState.IsLoggedIn && Ref.UnitBases.Cross != null)
+            else
             {
-                try
-                {
-                    UpdateBarState();
-                }
-                catch (Exception ex)
-                {
-                    PluginLog.Log(ex + "");
-                }
+                UpdateBarState();
             }
 
             return;

--- a/CrossUp.csproj
+++ b/CrossUp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors></Authors>
     <Company></Company>
-    <Version>0.1.2.0</Version>
+    <Version>0.1.3.0</Version>
     <Description>Customize the Cross Hotbar!</Description>
     <Copyright></Copyright>
     <PackageProjectUrl>https://github.com/ItsBexy/CrossUp</PackageProjectUrl>
@@ -32,8 +32,8 @@
 	  <PackageIcon>icon.png</PackageIcon>
 	  <PackageReadmeFile>README.md</PackageReadmeFile>
 	  <RepositoryUrl>https://github.com/ItsBexy/CrossUp</RepositoryUrl>
-	  <FileVersion>0.1.2.0</FileVersion>
-	  <AssemblyVersion>0.1.2.0</AssemblyVersion>
+	  <FileVersion>0.1.3.0</FileVersion>
+	  <AssemblyVersion>0.1.3.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CrossUpUI.cs
+++ b/CrossUpUI.cs
@@ -38,9 +38,8 @@ namespace CrossUp
         {
             if (!SettingsVisible) return;
 
-            ImGui.SetNextWindowSize(new Vector2(400, 630), ImGuiCond.Always);
-            if (ImGui.Begin("CrossUp Settings", ref this.settingsVisible,
-                ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse))
+            ImGui.SetNextWindowSize(new Vector2(400, 630), ImGuiCond.FirstUseEver);
+            if (ImGui.Begin("CrossUp Settings", ref this.settingsVisible))
             {
 
                 var sepExBar = this.configuration.SepExBar;

--- a/CrossUpUI.cs
+++ b/CrossUpUI.cs
@@ -315,7 +315,7 @@ namespace CrossUp
 
                                     this.crossUp.ResetHud();
                                     this.configuration.Save();
-                                    this.crossUp.ExBarActivate(i);
+                                    this.crossUp.EnableEx();
                                 }
                                 else
                                 {

--- a/Data/CrossUp.json
+++ b/Data/CrossUp.json
@@ -5,7 +5,7 @@
   "Description": "This plugin provides customizations for the look and feel of the Cross Hotbar\n\n-Split up the left/right hotbars\nDisplay Expanded Hold Controls Separately\n-Customize colors and element positions",
   "InternalName": "crossUp",
   "ApplicableVersion": "any",
-  "AssemblyVersion": "0.1.2.0",
+  "AssemblyVersion": "0.1.3.0",
   "Tags": [
     "hotbar",
     "ui",

--- a/NodeEdit.cs
+++ b/NodeEdit.cs
@@ -5,7 +5,7 @@ namespace CrossUp;
 
 public static unsafe partial class NodeEdit
 {
-    public struct NodeProps
+    public struct PropertySet
     {
         public bool? Visible { get; set; }
         public float? X { get; set; }
@@ -13,10 +13,10 @@ public static unsafe partial class NodeEdit
         public float? Scale { get; set; }
         public ushort? Width { get; set; }
         public ushort? Height { get; set; }
-        public Vector3? Color { get; set; }
         public float? Alpha { get; set; }
-        public int? OriginX { get; set; }
-        public int? OriginY { get; set; }
+        public int? OrigX { get; set; }
+        public int? OrigY { get; set; }
+        public Vector3? Color { get; set; }
     }
     public static void SetVis(AtkResNode* node,bool show)
     {
@@ -88,7 +88,7 @@ public static unsafe partial class NodeEdit
         node->Flags_2 |= 0xD;
         return;
     }
-    public static void SetVarious(AtkResNode* node, NodeProps props)
+    public static void SetVarious(AtkResNode* node, PropertySet props)
     {
         if (props.X != null) { node->X = (float)props.X; }
         if (props.Y != null) { node->Y = (float)props.Y; }
@@ -98,27 +98,26 @@ public static unsafe partial class NodeEdit
         if (props.Visible != null) { SetVis(node, (bool)props.Visible); }
         if (props.Color != null) { SetColor(node, (Vector3)props.Color); }
         if (props.Alpha != null) { SetAlpha(node, (float)props.Alpha); }
-        if (props.OriginX != null && props.OriginY != null) { SetOrigin(node, (int)props.OriginX, (int)props.OriginY); }
+        if (props.OrigX != null && props.OrigY != null) { SetOrigin(node, (int)props.OrigX, (int)props.OrigY); }
         node->Flags_2 |= 0xD;
         return;
     }
 
     public class ByLookup // grab and edit things using name and default props from Reference.cs
     {
-        public static void RelativePos(Ref.nodeProps props, float offX, float offY)
+        public static void RelativePos(Ref.NodeRef props, float offX, float offY)
         {
             SetPos(props.unitBase->UldManager.NodeList[props.Id], props.pos.X + offX, props.pos.Y + offY);
             return;
         }
-        public static void AbsoluteSize(Ref.nodeProps props, ushort? width = null, ushort? height = null)
+        public static void AbsoluteSize(Ref.NodeRef props, ushort? width = null, ushort? height = null)
         {
             if (width == null) { width = (ushort)props.size.X; }
             if (height == null) { height = (ushort)props.size.Y; }
             SetSize(props.unitBase->UldManager.NodeList[props.Id], (ushort)width, (ushort)height);
             return;
         }
-
-        public static void AbsolutePos(Ref.nodeProps props, float? x = null, float? y = null)
+        public static void AbsolutePos(Ref.NodeRef props, float? x = null, float? y = null)
         {
             if (x == null) { x = props.pos.X; }
             if (y == null) { y = props.pos.Y; }

--- a/Reference.cs
+++ b/Reference.cs
@@ -6,7 +6,6 @@ namespace CrossUp
 {
     public unsafe class Ref
     {
-        // POSITIONS AND REFERENCE
         public class UnitBases {
             public static AtkUnitBase*[] ActionBar =
             {
@@ -26,35 +25,35 @@ namespace CrossUp
             public static AtkUnitBase* RR = (AtkUnitBase*)Service.GameGui.GetAddonByName("_ActionDoubleCrossR", 1);
         };
 
-        public struct nodeProps
+        public struct NodeRef
         {
+            public AtkUnitBase* unitBase;
             public int Id;
             public Vector2 pos;
             public Vector2 size;
-            public AtkUnitBase* unitBase;
         };
 
         public class barNodes
         {
             public class Cross
             {
-                public static readonly nodeProps RootNode = new nodeProps { unitBase = UnitBases.Cross, Id = 0 };
-                public static readonly nodeProps Component = new nodeProps { unitBase = UnitBases.Cross, Id = 1, pos = new Vector2 { X = 18F, Y = 79F } };
-                public static readonly nodeProps selectBG = new nodeProps { unitBase = UnitBases.Cross, Id = 4, size = new Vector2 { X = 304, Y = 140 } };
-                public static readonly nodeProps miniSelectL = new nodeProps { unitBase = UnitBases.Cross, Id = 5, size = new Vector2 { X = 166, Y = 140 } };
-                public static readonly nodeProps miniSelectR = new nodeProps { unitBase = UnitBases.Cross, Id = 6, size = new Vector2 { X = 166, Y = 140 } };
-                public static readonly nodeProps VertLine = new nodeProps { unitBase = UnitBases.Cross, Id = 7, pos = new Vector2 { X = 271F, Y = 21F }, size = new Vector2 { X = 9, Y = 76 } };
-                public static readonly nodeProps[] Sets = {
-                    new nodeProps { unitBase = UnitBases.Cross, Id = 11, pos = new Vector2 { X = 0F, Y = 0F }},
-                    new nodeProps { unitBase = UnitBases.Cross, Id = 10, pos = new Vector2 { X = 138F, Y = 0F }},
-                    new nodeProps { unitBase = UnitBases.Cross, Id = 9, pos = new Vector2 { X = 284F, Y = 0F }},
-                    new nodeProps { unitBase = UnitBases.Cross, Id = 8, pos = new Vector2 { X = 422F, Y = 0F }},
+                public static readonly NodeRef RootNode = new NodeRef { unitBase = UnitBases.Cross, Id = 0 };
+                public static readonly NodeRef Component = new NodeRef { unitBase = UnitBases.Cross, Id = 1, pos = new Vector2 { X = 18F, Y = 79F } };
+                public static readonly NodeRef selectBG = new NodeRef { unitBase = UnitBases.Cross, Id = 4, size = new Vector2 { X = 304, Y = 140 } };
+                public static readonly NodeRef miniSelectL = new NodeRef { unitBase = UnitBases.Cross, Id = 5, size = new Vector2 { X = 166, Y = 140 } };
+                public static readonly NodeRef miniSelectR = new NodeRef { unitBase = UnitBases.Cross, Id = 6, size = new Vector2 { X = 166, Y = 140 } };
+                public static readonly NodeRef VertLine = new NodeRef { unitBase = UnitBases.Cross, Id = 7, pos = new Vector2 { X = 271F, Y = 21F }, size = new Vector2 { X = 9, Y = 76 } };
+                public static readonly NodeRef[] Sets = {
+                    new NodeRef { unitBase = UnitBases.Cross, Id = 11, pos = new Vector2 { X = 0F, Y = 0F }},
+                    new NodeRef { unitBase = UnitBases.Cross, Id = 10, pos = new Vector2 { X = 138F, Y = 0F }},
+                    new NodeRef { unitBase = UnitBases.Cross, Id = 9, pos = new Vector2 { X = 284F, Y = 0F }},
+                    new NodeRef { unitBase = UnitBases.Cross, Id = 8, pos = new Vector2 { X = 422F, Y = 0F }},
                 };
-                public static readonly nodeProps RT = new nodeProps { unitBase = UnitBases.Cross, Id = 19, pos = new Vector2 { X = 367F, Y = 11F } };
-                public static readonly nodeProps LT = new nodeProps { unitBase = UnitBases.Cross, Id = 20, pos = new Vector2 { X = 83F, Y = 11F } };
-                public static readonly nodeProps setText = new nodeProps { unitBase = UnitBases.Cross, Id = 21, pos = new Vector2 { X = 230F, Y = 170F } };
-                public static readonly nodeProps padlock = new nodeProps { unitBase = UnitBases.Cross, Id = 26, pos = new Vector2 { X = 284F, Y = 152F } };
-                public static readonly nodeProps changeSet = new nodeProps { unitBase = UnitBases.Cross, Id = 27, pos = new Vector2 { X = 146F, Y = 0F } };
+                public static readonly NodeRef RT = new NodeRef { unitBase = UnitBases.Cross, Id = 19, pos = new Vector2 { X = 367F, Y = 11F } };
+                public static readonly NodeRef LT = new NodeRef { unitBase = UnitBases.Cross, Id = 20, pos = new Vector2 { X = 83F, Y = 11F } };
+                public static readonly NodeRef setText = new NodeRef { unitBase = UnitBases.Cross, Id = 21, pos = new Vector2 { X = 230F, Y = 170F } };
+                public static readonly NodeRef padlock = new NodeRef { unitBase = UnitBases.Cross, Id = 26, pos = new Vector2 { X = 284F, Y = 152F } };
+                public static readonly NodeRef changeSet = new NodeRef { unitBase = UnitBases.Cross, Id = 27, pos = new Vector2 { X = 146F, Y = 0F } };
             }
         };
 
@@ -65,51 +64,51 @@ namespace CrossUp
             public static readonly int[,] XHB = { { 16, 17, 18, 19 }, { 20, 21, 22, 23 }, { 24, 25, 26, 27 }, { 28, 29, 30, 31 } };
         }
 
-        public static CrossUp.Position[] slotPositions = { // the positions for all the borrowed buttons
+        public static CrossUp.MetaSlot[] metaSlots = { // the positions for all the borrowed buttons
 
             //EXHB LEFT 0-7
-            new CrossUp.Position{ Scale=1.0F,X=0,Y=24,OrigX=94,OrigY=39,Visible=true,ScaleIndex=2},
-            new CrossUp.Position{ Scale=1.0F,X=42,Y=0,OrigX=52,OrigY=63,Visible=true,ScaleIndex=2},
-            new CrossUp.Position{ Scale=1.0F,X=84,Y=24,OrigX=10,OrigY=39,Visible=true,ScaleIndex=2},
-            new CrossUp.Position{ Scale=1.0F,X=42,Y=48,OrigX=52,OrigY=15,Visible=true,ScaleIndex=2},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=0,Y=24,OrigX=94,OrigY=39,Visible=true,ScaleIndex=2},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=42,Y=0,OrigX=52,OrigY=63,Visible=true,ScaleIndex=2},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=84,Y=24,OrigX=10,OrigY=39,Visible=true,ScaleIndex=2},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=42,Y=48,OrigX=52,OrigY=15,Visible=true,ScaleIndex=2},
 
-            new CrossUp.Position{ Scale=1.0F,X=138,Y=24,OrigX=94,OrigY=39,Visible=true,ScaleIndex=2},
-            new CrossUp.Position{ Scale=1.0F,X=180,Y=0,OrigX=52,OrigY=63,Visible=true,ScaleIndex=2},
-            new CrossUp.Position{ Scale=1.0F,X=222,Y=24,OrigX=10,OrigY=39,Visible=true,ScaleIndex=2},
-            new CrossUp.Position{ Scale=1.0F,X=180,Y=48,OrigX=52,OrigY=15,Visible=true,ScaleIndex=2},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=138,Y=24,OrigX=94,OrigY=39,Visible=true,ScaleIndex=2},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=180,Y=0,OrigX=52,OrigY=63,Visible=true,ScaleIndex=2},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=222,Y=24,OrigX=10,OrigY=39,Visible=true,ScaleIndex=2},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=180,Y=48,OrigX=52,OrigY=15,Visible=true,ScaleIndex=2},
             
             //EXHB RIGHT 8-15
-            new CrossUp.Position{ Scale=1.0F,X=0,Y=24,OrigX=94,OrigY=39,Visible=true,ScaleIndex=3},
-            new CrossUp.Position{ Scale=1.0F,X=42,Y=0,OrigX=52,OrigY=63,Visible=true,ScaleIndex=3},
-            new CrossUp.Position{ Scale=1.0F,X=84,Y=24,OrigX=10,OrigY=39,Visible=true,ScaleIndex=3},
-            new CrossUp.Position{ Scale=1.0F,X=42,Y=48,OrigX=52,OrigY=15,Visible=true,ScaleIndex=3},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=0,Y=24,OrigX=94,OrigY=39,Visible=true,ScaleIndex=3},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=42,Y=0,OrigX=52,OrigY=63,Visible=true,ScaleIndex=3},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=84,Y=24,OrigX=10,OrigY=39,Visible=true,ScaleIndex=3},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=42,Y=48,OrigX=52,OrigY=15,Visible=true,ScaleIndex=3},
 
-            new CrossUp.Position{ Scale=1.0F,X=138,Y=24,OrigX=94,OrigY=39,Visible=true,ScaleIndex=3},
-            new CrossUp.Position{ Scale=1.0F,X=180,Y=0,OrigX=52,OrigY=63,Visible=true,ScaleIndex=3},
-            new CrossUp.Position{ Scale=1.0F,X=222,Y=24,OrigX=10,OrigY=39,Visible=true,ScaleIndex=3},
-            new CrossUp.Position{ Scale=1.0F,X=180,Y=48,OrigX=52,OrigY=15,Visible=true,ScaleIndex=3},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=138,Y=24,OrigX=94,OrigY=39,Visible=true,ScaleIndex=3},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=180,Y=0,OrigX=52,OrigY=63,Visible=true,ScaleIndex=3},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=222,Y=24,OrigX=10,OrigY=39,Visible=true,ScaleIndex=3},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=180,Y=48,OrigX=52,OrigY=15,Visible=true,ScaleIndex=3},
             
             //MAIN BAR LEFT 16-23
-            new CrossUp.Position{ Scale=1.0F,X=-142,Y=24,OrigX=94,OrigY=39,Visible=true,ScaleIndex=0},
-            new CrossUp.Position{ Scale=1.0F,X=-100,Y=0,OrigX=52,OrigY=63,Visible=true,ScaleIndex=0},
-            new CrossUp.Position{ Scale=1.0F,X=-58,Y=24,OrigX=10,OrigY=39,Visible=true,ScaleIndex=0},
-            new CrossUp.Position{ Scale=1.0F,X=-100,Y=48,OrigX=52,OrigY=15,Visible=true,ScaleIndex=0},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=-142,Y=24,OrigX=94,OrigY=39,Visible=true,ScaleIndex=0},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=-100,Y=0,OrigX=52,OrigY=63,Visible=true,ScaleIndex=0},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=-58,Y=24,OrigX=10,OrigY=39,Visible=true,ScaleIndex=0},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=-100,Y=48,OrigX=52,OrigY=15,Visible=true,ScaleIndex=0},
 
-            new CrossUp.Position{ Scale=1.0F,X=-9,Y=24,OrigX=95,OrigY=39,Visible=true,ScaleIndex=0},
-            new CrossUp.Position{ Scale=1.0F,X=33,Y=0,OrigX=53,OrigY=63,Visible=true,ScaleIndex=0},
-            new CrossUp.Position{ Scale=1.0F,X=75,Y=24,OrigX=11,OrigY=39,Visible=true,ScaleIndex=0},
-            new CrossUp.Position{ Scale=1.0F,X=33,Y=48,OrigX=53,OrigY=15,Visible=true,ScaleIndex=0},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=-9,Y=24,OrigX=95,OrigY=39,Visible=true,ScaleIndex=0},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=33,Y=0,OrigX=53,OrigY=63,Visible=true,ScaleIndex=0},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=75,Y=24,OrigX=11,OrigY=39,Visible=true,ScaleIndex=0},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=33,Y=48,OrigX=53,OrigY=15,Visible=true,ScaleIndex=0},
             
             //MAIN BAR RIGHT 24-31
-            new CrossUp.Position{ Scale=1.0F,X=142,Y=24,OrigX=94,OrigY=39,Visible=true,ScaleIndex=1},
-            new CrossUp.Position{ Scale=1.0F,X=184,Y=0,OrigX=52,OrigY=63,Visible=true,ScaleIndex=1},
-            new CrossUp.Position{ Scale=1.0F,X=226,Y=24,OrigX=10,OrigY=39,Visible=true,ScaleIndex=1},
-            new CrossUp.Position{ Scale=1.0F,X=184,Y=48,OrigX=52,OrigY=15,Visible=true,ScaleIndex=1},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=142,Y=24,OrigX=94,OrigY=39,Visible=true,ScaleIndex=1},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=184,Y=0,OrigX=52,OrigY=63,Visible=true,ScaleIndex=1},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=226,Y=24,OrigX=10,OrigY=39,Visible=true,ScaleIndex=1},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=184,Y=48,OrigX=52,OrigY=15,Visible=true,ScaleIndex=1},
 
-            new CrossUp.Position{ Scale=1.0F,X=275,Y=24,OrigX=95,OrigY=39,Visible=true,ScaleIndex=1},
-            new CrossUp.Position{ Scale=1.0F,X=317,Y=0,OrigX=53,OrigY=63,Visible=true,ScaleIndex=1},
-            new CrossUp.Position{ Scale=1.0F,X=359,Y=24,OrigX=11,OrigY=39,Visible=true,ScaleIndex=1},
-            new CrossUp.Position{ Scale=1.0F,X=317,Y=48,OrigX=53,OrigY=15,Visible=true,ScaleIndex=1},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=275,Y=24,OrigX=95,OrigY=39,Visible=true,ScaleIndex=1},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=317,Y=0,OrigX=53,OrigY=63,Visible=true,ScaleIndex=1},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=359,Y=24,OrigX=11,OrigY=39,Visible=true,ScaleIndex=1},
+            new CrossUp.MetaSlot{ Scale=1.0F,X=317,Y=48,OrigX=53,OrigY=15,Visible=true,ScaleIndex=1},
         };
 
         public static readonly float[,] scaleMap = new float[7, 4] { // the scale each section of buttons should be at in each state
@@ -218,7 +217,5 @@ namespace CrossUp
             new Vector2{ X=117,Y=358 },
             new Vector2{ X=72,Y=618 },
         };
-
-
     }
 }


### PR DESCRIPTION
And restore restricted window functionality

I play on either a 1440p or 4K display, each of which as a much higher pixel density than a usual 1080p monitor, so I need to have larger fonts and UI scaling on literally every game I play. Unfortunately, for Dalamud, it's not a UI scale but a font scale, so it doesn't proportionally increase the size of the UI along with the font size, so text and UI often get cut off for statically sized ImGui windows.

By the way, congratulations on getting this plugin figured out and developed! I'm loving it so far! It automates a lot of tedium I used to do manually with the hotbars that ended up discouraging me from tinkering with my HUD layout and trying out new jobs.